### PR TITLE
Add Smithery to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # Inoyu Apache Unomi MCP Server
+[![smithery badge](https://smithery.ai/badge/@inoyu/mcp-unomi-server)](https://smithery.ai/server/@inoyu/mcp-unomi-server)
 
 A Model Context Protocol server enabling Claude to maintain user context through Apache Unomi profile management.
 
@@ -28,6 +29,15 @@ Watch how the MCP server enables Claude to maintain context and manage user prof
 
 ## Installation
 
+### Installing via Smithery
+
+To install Inoyu Apache Unomi Server for Claude Desktop automatically via [Smithery](https://smithery.ai/server/@inoyu/mcp-unomi-server):
+
+```bash
+npx -y @smithery/cli install @inoyu/mcp-unomi-server --client claude
+```
+
+### Installing manually
 To use with Claude Desktop, add the server config and environment variables:
 
 On MacOS: `~/Library/Application Support/Claude/claude_desktop_config.json`
@@ -434,4 +444,3 @@ For development or local installations:
   }
 }
 ```
-


### PR DESCRIPTION
This PR makes two changes to the README.

1. Adds installation instructions to automatically install Inoyu Apache Unomi Server for Claude Desktop using Smithery CLI. This makes it easier for users to install the MCP.
2. Adds a badge to show the number of installations from Smithery: https://smithery.ai/server/@inoyu/mcp-unomi-server

Let me know if any tweaks have to be made!